### PR TITLE
Unify release, tag & image names

### DIFF
--- a/.github/workflows/automated_release_and_build.yml
+++ b/.github/workflows/automated_release_and_build.yml
@@ -56,7 +56,7 @@ jobs:
         uses: ncipollo/release-action@v1.8.8
         with:
           name: ${{ env.RELEASE_VERSION }}
-          tag: v${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION }}
           prerelease: ${{ !(github.ref == 'refs/heads/master') }}
           commit: ${{ github.sha }}
 

--- a/.github/workflows/check_release_version.yml
+++ b/.github/workflows/check_release_version.yml
@@ -22,6 +22,6 @@ jobs:
 
       - name: Compare releases
         run: >-
-          if [ "${{ steps.last_release.outputs.release }}" = "$(printf 'v%s\n' $(cat .release-version))" ]; then
+          if [ "${{ steps.last_release.outputs.release }}" = "$(printf '%s\n' $(cat .release-version))" ]; then
             exit 1;
           fi


### PR DESCRIPTION
update github build script to unify the naming of github releases, github tags and docker images, to make deployments less confusing
