### PR TITLE
Apply needed patches

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,15 +1,15 @@
 # use publicly acessible env variables in this file
-#   https://flask.palletsprojects.com/en/1.1.x/cli/#environment-variables-from-dotenv
+#   https://flask.palletsprojects.com/en/2.2.x/cli/#environment-variables-from-dotenv
 
-# https://flask.palletsprojects.com/en/1.1.x/cli/#application-discovery
+# https://flask.palletsprojects.com/en/2.2.x/cli/#application-discovery
 FLASK_APP=baracoda
 
-# https://flask.palletsprojects.com/en/1.1.x/cli/#setting-command-options
+# https://flask.palletsprojects.com/en/2.2.x/cli/#setting-command-options
 FLASK_RUN_HOST=0.0.0.0
 FLASK_RUN_PORT=8000
 
-# https://flask.palletsprojects.com/en/1.1.x/config/#environment-and-debug-features
-FLASK_ENV=development
+# https://flask.palletsprojects.com/en/2.2.x/config/#DEBUG
+FLASK_DEBUG=true
 
 # path to the settings file which flask will use
 SETTINGS_PATH=config/development.py

--- a/baracoda/sql/schema.sql
+++ b/baracoda/sql/schema.sql
@@ -58,4 +58,4 @@ CREATE TABLE alembic_version
 INSERT INTO alembic_version
     (version_num)
 VALUES
-    ('bcd74f0a02ea');
+    ('db39b037a71d');


### PR DESCRIPTION
The database was failing to generate, but that turned out to be my `pipenv` environment.

After fixing the environment, the `flask init-db` command worked, but the `flask db upgrade` command complained about trying to apply changes that were already in the database.  I noticed the version is incorrect in the `schema.sql` file.

The `FLASK_ENV` variable is deprecated so I've changed it to `FLASK_DEBUG` as prompted and updated links to recent documentation on the environment options.