### PR TITLE
Fix issues with flask upgrade

### DIFF
--- a/baracoda/__init__.py
+++ b/baracoda/__init__.py
@@ -26,6 +26,7 @@ class SubRequest(Request):
     """
     A subclass to mitigate the forcing of application/json header
     """
+
     @property
     def json(self):
         return self.get_json(force=True)

--- a/baracoda/__init__.py
+++ b/baracoda/__init__.py
@@ -3,7 +3,7 @@ import logging.config
 from http import HTTPStatus
 
 import click
-from flask import Flask
+from flask import Flask, Request
 from flask.cli import with_appcontext
 
 from baracoda import barcodes
@@ -22,9 +22,22 @@ def init_db_command():
     click.echo("Reseting the database")
 
 
+class SubRequest(Request):
+    """
+    A subclass to mitigate the forcing of application/json header
+    """
+    @property
+    def json(self):
+        return self.get_json(force=True)
+
+
 def create_app(test_config=None):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=False)
+
+    # Overrides the default Request class with a request class that does not force application/json header
+    # for request.json call
+    app.request_class = SubRequest
 
     if test_config is None:
         # load the config, if it exists, when not testing


### PR DESCRIPTION
**Note**: The `application/json` header wasn't mandatory as per the previous implementations. But with Flask upgrade, this had been made mandatory. This pull request attends to that particular issue with existing consumers of Baracoda API, i.e., the existing consumers need to modify their own API to add `application/json` header along with the `POST` request.

The fix is more of a hack. It customises an existing `Request` class, and assigns the customised class as the class for request processing.

#### Changes proposed in this pull request

- This update makes `application/json` header optional.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
