### PR TITLE
Y24-036: Fixed previous stable images being deleted

### DIFF
--- a/.github/workflows/automated_release_and_build.yml
+++ b/.github/workflows/automated_release_and_build.yml
@@ -89,6 +89,5 @@ jobs:
           account-type: org
           org-name: sanger
           keep-at-least: 5
-          skip-tags: latest
+          skip-tags: latest, *[!develop] # This will DELETE any images where the tag contains ANY characters in "develop", excluding '!'
           token: ${{ secrets.REMOVE_OLD_IMAGES }}
-


### PR DESCRIPTION
Closes https://github.com/sanger/General-Backlog-Items/issues/378

#### Changes proposed in this pull request

- The workflow configuration file was changed so that all images marked with the develop tag (older than four months) will be deleted while previous stable releases will be kept regardless.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
