### PR TITLE
Y25-270-2 - Improve baracoda error logging

### DIFF
--- a/baracoda/barcodes.py
+++ b/baracoda/barcodes.py
@@ -132,7 +132,7 @@ def positive_value(value: int) -> int:
     """
     if value > 0:
         return value
-    raise InvalidCountError()
+    raise InvalidCountError("Count value is not a positive integer")
 
 
 def get_count_param():
@@ -150,9 +150,12 @@ def get_count_param():
     """
     if "count" in request.values:
         try:
-            return positive_value(int(request.values["count"]))
-        except Exception:
-            raise InvalidCountError("Count value is not a positive integer")
+            # int can throw an exception if the value is not convertible
+            count = int(request.values["count"])
+        except ValueError:
+            raise InvalidCountError("Count value is not a valid integer")
+
+        return positive_value(count)
     else:
         try:
             if request.json and ("count" in request.json):

--- a/baracoda/barcodes.py
+++ b/baracoda/barcodes.py
@@ -47,12 +47,16 @@ def get_new_barcode_group(prefix: str) -> Tuple[Any, int]:
         )
 
     except InvalidPrefixError as e:
+        logger.error(f"{e} {prefix}")
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.BAD_REQUEST
     except InvalidCountError as e:
+        logger.error(e)
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.UNPROCESSABLE_ENTITY
     except BadRequest as e:
+        logger.error(e)
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.BAD_REQUEST
     except Exception as e:
+        logger.error(e)
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
@@ -78,8 +82,10 @@ def get_new_barcode(prefix: str) -> Tuple[Any, int]:
         return barcode.to_dict(), HTTPStatus.CREATED
 
     except InvalidPrefixError as e:
+        logger.error(f"{e} {prefix}")
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.BAD_REQUEST
     except Exception as e:
+        logger.error(e)
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
@@ -107,8 +113,10 @@ def get_last_barcode(prefix: str) -> Tuple[Any, int]:
         return barcode.to_dict(), HTTPStatus.OK
 
     except InvalidPrefixError as e:
+        logger.error(f"{e} {prefix}")
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.BAD_REQUEST
     except Exception as e:
+        logger.error(e)
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
@@ -141,7 +149,10 @@ def get_count_param():
 
     """
     if "count" in request.values:
-        return positive_value(int(request.values["count"]))
+        try:
+            return positive_value(int(request.values["count"]))
+        except Exception:
+            raise InvalidCountError("Count value is not a positive integer")
     else:
         try:
             if request.json and ("count" in request.json):

--- a/baracoda/child_barcodes.py
+++ b/baracoda/child_barcodes.py
@@ -6,7 +6,7 @@ from sqlalchemy import exc
 from flask_cors import CORS
 
 from baracoda.operations import BarcodeOperations, InvalidParentBarcode, InvalidPrefixForChildrenCreation
-from baracoda.exceptions import InvalidCountError, InvalidBarcodeError
+from baracoda.exceptions import InvalidCountError, InvalidBarcodeError, InvalidPrefixError
 from baracoda.types import BarcodeParentInfoType
 from typing import cast
 
@@ -59,17 +59,25 @@ def new_child_barcodes(prefix: str) -> Tuple[Any, int]:
             HTTPStatus.CREATED,
         )
     except InvalidCountError as e:
+        logger.error(e)
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.UNPROCESSABLE_ENTITY
     except InvalidBarcodeError as e:
+        logger.error(e)
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.UNPROCESSABLE_ENTITY
     except exc.IntegrityError as e:
         logger.error(f"{type(e).__name__}: Two creation requests recieved for the same barcode")
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.INTERNAL_SERVER_ERROR
     except InvalidParentBarcode as e:
+        logger.error(e)
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.INTERNAL_SERVER_ERROR
     except InvalidPrefixForChildrenCreation as e:
+        logger.error(f"{e} {prefix}")
+        return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.INTERNAL_SERVER_ERROR
+    except InvalidPrefixError as e:
+        logger.error(f"{e} {prefix}")
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.INTERNAL_SERVER_ERROR
     except Exception as e:
+        logger.error(e)
         return {"errors": [f"{type(e).__name__}"]}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 

--- a/tests/test_barcodes.py
+++ b/tests/test_barcodes.py
@@ -75,7 +75,7 @@ def test_get_new_barcodes_group_without_count(client, caplog):
 def test_get_new_barcodes_group_with_wrong_value_count(client, caplog):
     response = client.post("/barcodes_group/SANG/new?count=WRONG")
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    assert "InvalidCountError: Count value is not a positive integer" in caplog.text
+    assert "InvalidCountError: Count value is not a valid integer" in caplog.text
 
 
 def test_get_new_barcodes_group_with_wrong_value_negative(client, caplog):


### PR DESCRIPTION
Closes #578 

#### Changes proposed in this pull request

- Adds error logging when an error occurs in the barcode endpoints.
- Improves barcodes_groups count param error handling (handles negatives and strings).

