### PR TITLE
build: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     interval: daily
     time: "07:00"
     timezone: Europe/London
+  cooldown:
+    default-days: 5
+    semver-major-days: 30
+    semver-minor-days: 7
+    semver-patch-days: 3
   open-pull-requests-limit: 10
   labels:
     - "dependencies"


### PR DESCRIPTION
Adds a [cooldown period](https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/) to dependency updates - should hopefully reduce some of the noise...

#### Changes proposed in this pull request

- Add suggested timings for cooldown from 3 days to 1 month (depending on the significance of the upgrade)

See the [dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) for more info on parameter usage.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
